### PR TITLE
chore(action): standardize runtime and entrypoint metadata

### DIFF
--- a/notify-on-branch-delete/action.yml
+++ b/notify-on-branch-delete/action.yml
@@ -16,5 +16,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js' 

--- a/notify-on-commit-comment/action.yml
+++ b/notify-on-commit-comment/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: 'Telegram Chat ID'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js' 

--- a/notify-on-failure/action.yml
+++ b/notify-on-failure/action.yml
@@ -17,5 +17,5 @@ inputs:
     description: 'Name of the failed job'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js' 

--- a/notify-on-issue/action.yml
+++ b/notify-on-issue/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: 'Telegram Chat ID'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js' 

--- a/notify-on-pr/action.yml
+++ b/notify-on-pr/action.yml
@@ -17,6 +17,5 @@ inputs:
     description: 'GitHub Token for fetching PR details'
     required: true
 runs:
-  using: 'node16'
-  pre: 'npm install'
-  main: 'index.js'
+  using: 'node20'
+  main: 'dist/index.js'

--- a/notify-on-push/action.yml
+++ b/notify-on-push/action.yml
@@ -62,6 +62,6 @@ inputs:
 
 # 액션 실행 방식 정의
 runs:
-  using: 'node16' # 실행 환경: Node.js 16 버전 사용'
+  using: 'node20' # 실행 환경: Node.js 20 버전 사용
   main: 'dist/index.js' 
 

--- a/notify-on-release/action.yml
+++ b/notify-on-release/action.yml
@@ -13,6 +13,6 @@ inputs:
   telegram_chat_id:
     description: 'Telegram Chat ID'
     required: false
-  runs:
-    using: 'node16'
-    main: 'dist/index.js' 
+runs:
+  using: 'node20'
+  main: 'dist/index.js'


### PR DESCRIPTION
## Summary
- standardize all action metadata to use `runs.using: node20`
- standardize action execution entrypoint to `runs.main: dist/index.js`
- fix malformed `notify-on-release/action.yml` structure where `runs` was incorrectly nested under `inputs`
- remove runtime install step from `notify-on-pr` metadata (use committed dist artifacts)
- update inline runtime comment in `notify-on-push/action.yml` for consistency

## Validation
- `actionlint` is not installed in this environment
- ran YAML/static spot-check with Ruby to verify:
  - each `notify-*/action.yml` has valid top-level `runs` map
  - `runs.using == node20` and `runs.main == dist/index.js`
  - `dist/index.js` exists in each action directory
