### PR TITLE
chore: standardize action metadata validation in CI

### DIFF
--- a/.github/workflows/metadata-lint.yml
+++ b/.github/workflows/metadata-lint.yml
@@ -1,0 +1,22 @@
+name: Metadata Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate-metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run repository metadata checks
+        run: ./scripts/validate-action-metadata.sh
+
+      - name: actionlint
+        uses: reviewdog/actionlint@v1
+        with:
+          fail_on_error: true

--- a/README.en.md
+++ b/README.en.md
@@ -19,6 +19,7 @@ A collection of GitHub Actions for sending notifications about GitHub events to 
 
 - All actions run on `runs.using: node20`.
 - Execution entry points in `action.yml` are standardized to `dist/index.js`.
+- `.github/workflows/metadata-lint.yml` checks metadata consistency in CI using `scripts/validate-action-metadata.sh` + `actionlint`.
 - Release artifacts use `ncc` bundles and commit generated `dist/` output.
 
 ## 🔧 Setup Guide

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ GitHub 이벤트에 대한 알림을 다양한 플랫폼으로 전송하는 GitH
 
 - 모든 액션은 `runs.using: node20` 기준으로 동작합니다.
 - `action.yml`의 실행 엔트리는 `dist/index.js`로 통일되어 있습니다.
+- `.github/workflows/metadata-lint.yml`에서 `scripts/validate-action-metadata.sh` + `actionlint`로 메타데이터 정합성을 CI에서 점검합니다.
 - 배포 시 `ncc`로 번들된 `dist/` 산출물을 함께 커밋하는 방식을 사용합니다.
 
 ## 🔧 설정 방법

--- a/notify-on-failure/action.yml
+++ b/notify-on-failure/action.yml
@@ -18,4 +18,4 @@ inputs:
     required: false
 runs:
   using: 'node20'
-  main: 'dist/index.js' 
+  main: 'dist/index.js'

--- a/scripts/validate-action-metadata.sh
+++ b/scripts/validate-action-metadata.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+expected_runtime="node20"
+expected_main="dist/index.js"
+
+status=0
+
+for action_file in notify-*/action.yml; do
+  if [[ ! -f "$action_file" ]]; then
+    continue
+  fi
+
+  action_dir="$(dirname "$action_file")"
+  runtime="$(awk -F": " '/^[[:space:]]*using:/ {gsub(/'"'"'/, "", $2); print $2; exit}' "$action_file")"
+  main="$(awk -F": " '/^[[:space:]]*main:/ {gsub(/'"'"'/, "", $2); print $2; exit}' "$action_file")"
+
+  if [[ "$runtime" != "$expected_runtime" ]]; then
+    echo "[FAIL] $action_file runs.using must be '$expected_runtime' (found: '${runtime:-<missing>}')"
+    status=1
+  fi
+
+  if [[ "$main" != "$expected_main" ]]; then
+    echo "[FAIL] $action_file runs.main must be '$expected_main' (found: '${main:-<missing>}')"
+    status=1
+  fi
+
+  if [[ ! -f "$action_dir/$expected_main" ]]; then
+    echo "[FAIL] $action_dir/$expected_main does not exist"
+    status=1
+  fi
+
+done
+
+if [[ $status -eq 0 ]]; then
+  echo "[OK] All action metadata files use runs.using=$expected_runtime and runs.main=$expected_main"
+fi
+
+exit $status


### PR DESCRIPTION
## Summary\n- add CI workflow to validate action metadata and GitHub Actions workflow syntax\n- add script to enforce `runs.using=node20`, `runs.main=dist/index.js`, and dist entrypoint existence across all actions\n- fix trailing whitespace in `notify-on-failure/action.yml` and document validation flow in README files\n\n## Validation\n- ./scripts/validate-action-metadata.sh (pass)\n- local actionlint CLI not installed; added CI actionlint step via reviewdog/actionlint\n