### PR TITLE
chore(ci): add action metadata guardrails

### DIFF
--- a/.github/workflows/validate-actions.yml
+++ b/.github/workflows/validate-actions.yml
@@ -1,0 +1,20 @@
+name: Validate Actions
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1
+
+      - name: Validate action metadata conventions
+        run: ./scripts/validate-actions.sh

--- a/README.en.md
+++ b/README.en.md
@@ -20,6 +20,7 @@ A collection of GitHub Actions for sending notifications about GitHub events to 
 - All actions run on `runs.using: node20`.
 - Execution entry points in `action.yml` are standardized to `dist/index.js`.
 - Release artifacts use `ncc` bundles and commit generated `dist/` output.
+- CI enforces metadata conventions (`node20`, `dist/index.js`) using `actionlint` + `scripts/validate-actions.sh`.
 
 ## 🔧 Setup Guide
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ GitHub 이벤트에 대한 알림을 다양한 플랫폼으로 전송하는 GitH
 - 모든 액션은 `runs.using: node20` 기준으로 동작합니다.
 - `action.yml`의 실행 엔트리는 `dist/index.js`로 통일되어 있습니다.
 - 배포 시 `ncc`로 번들된 `dist/` 산출물을 함께 커밋하는 방식을 사용합니다.
+- CI에서 `actionlint` + `scripts/validate-actions.sh`를 통해 메타데이터 규칙(`node20`, `dist/index.js`)을 자동 검증합니다.
 
 ## 🔧 설정 방법
 

--- a/scripts/validate-actions.sh
+++ b/scripts/validate-actions.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+failures=0
+
+while IFS= read -r -d '' action_file; do
+  action_dir="$(dirname "$action_file")"
+  rel="${action_dir#./}"
+
+  using=$(awk -F"'" '/^  using:/{print $2}' "$action_file" | head -n1)
+  main=$(awk -F"'" '/^  main:/{print $2}' "$action_file" | head -n1)
+
+  if [[ "$using" != "node20" ]]; then
+    echo "[FAIL] $rel/action.yml: runs.using must be 'node20' (got: ${using:-<missing>})"
+    failures=1
+  fi
+
+  if [[ "$main" != "dist/index.js" ]]; then
+    echo "[FAIL] $rel/action.yml: runs.main must be 'dist/index.js' (got: ${main:-<missing>})"
+    failures=1
+  fi
+
+  if [[ ! -f "$action_dir/dist/index.js" ]]; then
+    echo "[FAIL] $rel/dist/index.js: file is missing"
+    failures=1
+  fi
+done < <(find . -maxdepth 2 -type f -name action.yml -print0)
+
+if [[ $failures -ne 0 ]]; then
+  exit 1
+fi
+
+echo "All action metadata checks passed."


### PR DESCRIPTION
## Summary
- add CI workflow to validate GitHub Action metadata on PR/push
- enforce `runs.using: node20` and `runs.main: dist/index.js` across all action directories
- verify bundled `dist/index.js` exists for every action
- document the validation policy in Korean/English READMEs

## Validation
- `./scripts/validate-actions.sh` (pass)
- local `actionlint` run skipped because binary is not installed; CI runs `rhysd/actionlint@v1`

## Why
This reduces metadata drift and catches runtime/entrypoint mismatches early, improving compatibility and release stability.
