### PR TITLE
chore: enforce action metadata consistency checks

### DIFF
--- a/.github/workflows/metadata-consistency.yml
+++ b/.github/workflows/metadata-consistency.yml
@@ -1,0 +1,15 @@
+name: Metadata Consistency
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate-action-metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate action.yml runtime and dist entry
+        run: bash scripts/validate-actions-metadata.sh

--- a/README.en.md
+++ b/README.en.md
@@ -20,6 +20,13 @@ A collection of GitHub Actions for sending notifications about GitHub events to 
 - All actions run on `runs.using: node20`.
 - Execution entry points in `action.yml` are standardized to `dist/index.js`.
 - Release artifacts use `ncc` bundles and commit generated `dist/` output.
+- Metadata consistency is automatically validated in `.github/workflows/metadata-consistency.yml` on PRs and pushes to `main`.
+
+You can run the same check locally with:
+
+```bash
+bash scripts/validate-actions-metadata.sh
+```
 
 ## 🔧 Setup Guide
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ GitHub 이벤트에 대한 알림을 다양한 플랫폼으로 전송하는 GitH
 - 모든 액션은 `runs.using: node20` 기준으로 동작합니다.
 - `action.yml`의 실행 엔트리는 `dist/index.js`로 통일되어 있습니다.
 - 배포 시 `ncc`로 번들된 `dist/` 산출물을 함께 커밋하는 방식을 사용합니다.
+- PR/메인 브랜치 푸시 시 `.github/workflows/metadata-consistency.yml`에서 메타데이터 정합성을 자동 검증합니다.
+
+로컬에서도 아래 명령으로 동일 검증을 실행할 수 있습니다.
+
+```bash
+bash scripts/validate-actions-metadata.sh
+```
 
 ## 🔧 설정 방법
 

--- a/scripts/validate-actions-metadata.sh
+++ b/scripts/validate-actions-metadata.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+shopt -s nullglob
+
+action_files=(notify-*/action.yml)
+if [ ${#action_files[@]} -eq 0 ]; then
+  echo "No action.yml files found under notify-* directories."
+  exit 1
+fi
+
+fail=0
+
+for file in "${action_files[@]}"; do
+  dir="$(dirname "$file")"
+  using="$(sed -nE "s/^[[:space:]]*using:[[:space:]]*'?(node[0-9]+)'?[[:space:]]*$/\1/p" "$file" | head -n1)"
+  main="$(sed -nE "s/^[[:space:]]*main:[[:space:]]*'?(dist\/index\.js)'?[[:space:]]*$/\1/p" "$file" | head -n1)"
+
+  if [ "$using" != "node20" ]; then
+    echo "[ERROR] $file -> runs.using must be node20 (found: ${using:-<missing>})"
+    fail=1
+  fi
+
+  if [ "$main" != "dist/index.js" ]; then
+    echo "[ERROR] $file -> runs.main must be dist/index.js (found: ${main:-<missing>})"
+    fail=1
+  fi
+
+  if [ ! -f "$dir/dist/index.js" ]; then
+    echo "[ERROR] $file -> $dir/dist/index.js is missing"
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+echo "All action metadata checks passed (${#action_files[@]} actions)."


### PR DESCRIPTION
## Summary
- add a repository-level metadata consistency workflow for all notify actions
- add `scripts/validate-actions-metadata.sh` to validate `runs.using`, `runs.main`, and committed `dist/index.js`
- document local validation command in Korean/English READMEs

## Validation
- `bash scripts/validate-actions-metadata.sh`
- `actionlint` is not available in the current runner environment (command not found), so the static metadata script was used as the minimum check.
