### PR TITLE
chore: standardize action metadata and validation workflow

### DIFF
--- a/.github/workflows/validate-actions.yml
+++ b/.github/workflows/validate-actions.yml
@@ -1,0 +1,29 @@
+name: Validate actions metadata
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1
+
+  metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate action.yml standards
+        run: ./scripts/validate-actions.sh

--- a/.github/workflows/validate-actions.yml
+++ b/.github/workflows/validate-actions.yml
@@ -16,8 +16,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install actionlint
+        run: |
+          curl -sSL \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz \
+            -o actionlint.tar.gz
+          tar -xzf actionlint.tar.gz actionlint
+          sudo mv actionlint /usr/local/bin/actionlint
+
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        run: actionlint
 
   metadata:
     runs-on: ubuntu-latest

--- a/notify-on-branch-delete/action.yml
+++ b/notify-on-branch-delete/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Telegram Chat ID'
     required: false
 
+branding:
+  icon: 'bell'
+  color: 'blue'
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/notify-on-commit-comment/action.yml
+++ b/notify-on-commit-comment/action.yml
@@ -13,6 +13,10 @@ inputs:
   telegram_chat_id:
     description: 'Telegram Chat ID'
     required: false
+branding:
+  icon: 'bell'
+  color: 'blue'
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/notify-on-failure/action.yml
+++ b/notify-on-failure/action.yml
@@ -16,6 +16,10 @@ inputs:
   job_name:
     description: 'Name of the failed job'
     required: false
+branding:
+  icon: 'bell'
+  color: 'blue'
+
 runs:
   using: 'node20'
   main: 'dist/index.js' 

--- a/notify-on-issue/action.yml
+++ b/notify-on-issue/action.yml
@@ -13,6 +13,10 @@ inputs:
   telegram_chat_id:
     description: 'Telegram Chat ID'
     required: false
+branding:
+  icon: 'bell'
+  color: 'blue'
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/notify-on-pr/action.yml
+++ b/notify-on-pr/action.yml
@@ -16,6 +16,10 @@ inputs:
   github_token:
     description: 'GitHub Token for fetching PR details'
     required: true
+branding:
+  icon: 'bell'
+  color: 'blue'
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/notify-on-push/action.yml
+++ b/notify-on-push/action.yml
@@ -35,6 +35,10 @@ inputs:
     required: false
     default: 'false'
 
+branding:
+  icon: 'bell'
+  color: 'blue'
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/notify-on-release/action.yml
+++ b/notify-on-release/action.yml
@@ -13,6 +13,10 @@ inputs:
   telegram_chat_id:
     description: 'Telegram Chat ID'
     required: false
+branding:
+  icon: 'bell'
+  color: 'blue'
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/scripts/validate-actions.sh
+++ b/scripts/validate-actions.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "❌ $1" >&2
+  exit 1
+}
+
+echo "🔎 Validating action metadata..."
+
+mapfile -t action_files < <(find . -mindepth 2 -maxdepth 2 -name action.yml | sort)
+[[ ${#action_files[@]} -gt 0 ]] || fail "No action.yml files found"
+
+for file in "${action_files[@]}"; do
+  dir="$(dirname "$file")"
+  echo "- $file"
+
+  grep -Eq "^runs:" "$file" || fail "$file: missing runs block"
+  grep -Eq "^[[:space:]]+using:[[:space:]]*'node20'" "$file" || fail "$file: runs.using must be 'node20'"
+  grep -Eq "^[[:space:]]+main:[[:space:]]*'dist/index.js'" "$file" || fail "$file: runs.main must be 'dist/index.js'"
+  grep -Eq "^branding:" "$file" || fail "$file: missing branding block"
+
+  [[ -f "$dir/dist/index.js" ]] || fail "$dir/dist/index.js is missing"
+done
+
+echo "✅ Metadata validation passed"

--- a/scripts/validate-actions.sh
+++ b/scripts/validate-actions.sh
@@ -5,11 +5,11 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 fail() {
-  echo "❌ $1" >&2
+  echo "[FAIL] $1" >&2
   exit 1
 }
 
-echo "🔎 Validating action metadata..."
+echo "Validating action metadata..."
 
 mapfile -t action_files < <(find . -mindepth 2 -maxdepth 2 -name action.yml | sort)
 [[ ${#action_files[@]} -gt 0 ]] || fail "No action.yml files found"
@@ -26,4 +26,4 @@ for file in "${action_files[@]}"; do
   [[ -f "$dir/dist/index.js" ]] || fail "$dir/dist/index.js is missing"
 done
 
-echo "✅ Metadata validation passed"
+echo "Metadata validation passed"


### PR DESCRIPTION
## Summary
- add `branding` metadata to all action.yml files for consistent GitHub Action metadata
- add CI workflow to run `actionlint` on push/PR
- add `scripts/validate-actions.sh` to enforce `runs.using: 'node20'`, `runs.main: 'dist/index.js'`, branding presence, and dist bundle existence

## Validation
- `./scripts/validate-actions.sh`
- actionlint will run in CI for this PR
