### PR TITLE
chore(ci): harden action metadata consistency checks

### DIFF
--- a/.github/workflows/metadata-consistency.yml
+++ b/.github/workflows/metadata-consistency.yml
@@ -13,3 +13,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate action.yml runtime and dist entry
         run: bash scripts/validate-actions-metadata.sh
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1

--- a/README.en.md
+++ b/README.en.md
@@ -20,7 +20,7 @@ A collection of GitHub Actions for sending notifications about GitHub events to 
 - All actions run on `runs.using: node20`.
 - Execution entry points in `action.yml` are standardized to `dist/index.js`.
 - Release artifacts use `ncc` bundles and commit generated `dist/` output.
-- Metadata consistency is automatically validated in `.github/workflows/metadata-consistency.yml` on PRs and pushes to `main`.
+- Metadata consistency and workflow syntax (`actionlint`) are automatically validated in `.github/workflows/metadata-consistency.yml` on PRs and pushes to `main`.
 
 You can run the same check locally with:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GitHub 이벤트에 대한 알림을 다양한 플랫폼으로 전송하는 GitH
 - 모든 액션은 `runs.using: node20` 기준으로 동작합니다.
 - `action.yml`의 실행 엔트리는 `dist/index.js`로 통일되어 있습니다.
 - 배포 시 `ncc`로 번들된 `dist/` 산출물을 함께 커밋하는 방식을 사용합니다.
-- PR/메인 브랜치 푸시 시 `.github/workflows/metadata-consistency.yml`에서 메타데이터 정합성을 자동 검증합니다.
+- PR/메인 브랜치 푸시 시 `.github/workflows/metadata-consistency.yml`에서 메타데이터 정합성과 워크플로 구문(`actionlint`)을 자동 검증합니다.
 
 로컬에서도 아래 명령으로 동일 검증을 실행할 수 있습니다.
 

--- a/notify-on-failure/package.json
+++ b/notify-on-failure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notify-on-failure",
   "version": "1.0.0",
-  "description": "GitHub Action for notifying Slack on push events",
+  "description": "GitHub Action for notifying Slack on workflow failure events",
   "main": "dist/index.js",
   "scripts": {
     "build": "ncc build index.js -o dist"

--- a/scripts/validate-actions-metadata.sh
+++ b/scripts/validate-actions-metadata.sh
@@ -16,6 +16,8 @@ fail=0
 
 for file in "${action_files[@]}"; do
   dir="$(dirname "$file")"
+  package_json="$dir/package.json"
+
   using="$(sed -nE "s/^[[:space:]]*using:[[:space:]]*'?(node[0-9]+)'?[[:space:]]*$/\1/p" "$file" | head -n1)"
   main="$(sed -nE "s/^[[:space:]]*main:[[:space:]]*'?(dist\/index\.js)'?[[:space:]]*$/\1/p" "$file" | head -n1)"
 
@@ -31,6 +33,25 @@ for file in "${action_files[@]}"; do
 
   if [ ! -f "$dir/dist/index.js" ]; then
     echo "[ERROR] $file -> $dir/dist/index.js is missing"
+    fail=1
+  fi
+
+  if [ ! -f "$package_json" ]; then
+    echo "[ERROR] $file -> $package_json is missing"
+    fail=1
+    continue
+  fi
+
+  package_main="$(node -p "try { require('./$package_json').main || '' } catch (e) { '' }")"
+  package_engine="$(node -p "try { (require('./$package_json').engines || {}).node || '' } catch (e) { '' }")"
+
+  if [ "$package_main" != "dist/index.js" ]; then
+    echo "[ERROR] $package_json -> main must be dist/index.js (found: ${package_main:-<missing>})"
+    fail=1
+  fi
+
+  if [ "$package_engine" != ">=20" ]; then
+    echo "[ERROR] $package_json -> engines.node must be >=20 (found: ${package_engine:-<missing>})"
     fail=1
   fi
 done


### PR DESCRIPTION
## Summary
- add stricter metadata validation in `scripts/validate-actions-metadata.sh` for `package.json` consistency (`main: dist/index.js`, `engines.node: >=20`)
- add `actionlint` CI job to catch workflow syntax issues earlier
- fix inaccurate `notify-on-failure/package.json` description and align docs with current validation scope

## Validation
- `bash scripts/validate-actions-metadata.sh` passed locally
- local `actionlint` command unavailable in this environment (CI job added to enforce it on PR)
